### PR TITLE
Fix option preview

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,7 @@
         "http://*/*",
         "https://*/*"
     ],
+    "content_security_policy": "script-src 'self' 'sha256-8E/SrsMdfNkLa3wOhbeFBZEldMD1DCZagNOCJI8j9iI=' 'unsafe-eval'; object-src 'self'",
     "version": "1.3.4",
     "web_accessible_resources": [
         "/readability/readability.js",

--- a/redux/example.html
+++ b/redux/example.html
@@ -164,7 +164,7 @@ See <A href="http://wikimediafoundation.org/wiki/Terms_of_Use">Terms of Use</A> 
 <script type="text/javascript">
 function inject(js)
 {
-    document.location = 'javascript:' + js;
+    eval(js);
 }
 
 parent.settings.hello_from_child(window);


### PR DESCRIPTION
Fixes the options preview by setting a content security policy as described [here](https://developer.chrome.com/extensions/contentSecurityPolicy).